### PR TITLE
Add XSS protection

### DIFF
--- a/lib/chat.js
+++ b/lib/chat.js
@@ -138,6 +138,13 @@ var BATC_Chat = (function() {
         }
         else
         {
+            textMsg = textMsg
+                        .replace(/&/g, "&amp;")
+                        .replace(/</g, "&lt;")
+                        .replace(/>/g, "&gt;")
+                        .replace(/"/g, "&quot;")
+                        .replace(/'/g, "&#039;");
+
         	var url_parts;
             var url_prefix;
             return textMsg.replace(hrefRegex, function(url) {


### PR DESCRIPTION
Escape HTML tags in `messageStripAndHrefs` so URLs can be re-enabled in the WB chat. Maybe not every character is included, but `<` and `>` are and that should prevent harmful XSS injection.

Signed-off-by: João Silva <jgc3silva@gmail.com>